### PR TITLE
feat: optionally add global middleware

### DIFF
--- a/src/Bootloader/GraphQLBootloader.php
+++ b/src/Bootloader/GraphQLBootloader.php
@@ -12,8 +12,8 @@ use Andi\GraphQL\ObjectFieldResolver\ObjectFieldResolver;
 use Andi\GraphQL\ObjectFieldResolver\ObjectFieldResolverInterface;
 use Andi\GraphQL\Spiral\Command\ConfigCommand;
 use Andi\GraphQL\Spiral\Common\SchemaWarmupper;
-use Andi\GraphQL\Spiral\Config\GraphQLConfig;
 use Andi\GraphQL\Spiral\Common\ValueResolver;
+use Andi\GraphQL\Spiral\Config\GraphQLConfig;
 use Andi\GraphQL\Spiral\Listener\AdditionalFieldListener;
 use Andi\GraphQL\Spiral\Listener\AttributedMutationFieldListener;
 use Andi\GraphQL\Spiral\Listener\AttributedQueryFieldListener;
@@ -81,7 +81,9 @@ final class GraphQLBootloader extends Bootloader
             'url' => $env->get('GRAPHQL_URL', '/api/graphql'),
         ]);
 
-        $http->addMiddleware(GraphQLMiddleware::class);
+        if (!empty($this->configurator->getConfig('graphql')['url'])) {
+            $http->addMiddleware(GraphQLMiddleware::class);
+        }
 
         $console->addCommand(ConfigCommand::class);
         $kernel->bootstrapped(static function (Schema $schema): void {

--- a/src/Controller/GraphQLController.php
+++ b/src/Controller/GraphQLController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Andi\GraphQL\Spiral\Controller;
+
+use GraphQL\Server\StandardServer;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final class GraphQLController
+{
+    public function __construct(
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly StandardServer $server,
+    ) {
+    }
+
+    public function graphql(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = $this->responseFactory->createResponse();
+        $stream = $this->streamFactory->createStream();
+
+        $response = $this->server->processPsrRequest($request, $response, $stream);
+        assert($response instanceof ResponseInterface);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Adds option to disable global `GraphQLMiddleware` and replace it with GraphQLController:

```php

// RoutesBootloader.php

protected function defineRoutes(RoutingConfigurator $routes): void
{
  $routes
    ->add('api.graphql.handle', '/api/graphql')
    ->methods(['GET', 'POST'])
    ->action(GraphQLController::class, 'graphql');
}