### PR TITLE
Proxy Container & Invoker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.1",
         "andi-lab/graphql-php": "^1.0.1",
-        "spiral/framework": "^3.8.4"
+        "spiral/framework": "^3.12"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Without proxying the container & invoker, all container binding resolution was performed in the "root" scope. This led to the invoker being unable to resolve scope-dependent arguments:

```php
#[QueryField(name: 'customer')]
public function getCustomer(
  #[Argument(type: 'ID!')]
  string $id,
  ActorInterface $actor, // https://spiral.dev/docs/security-authentication/current
): Customer {
  ...
}
```

Without these changes, it would lead to `Can't resolve 'ActorInterface'` exception

See https://github.com/andrey-mokhov/graphql-php/pull/60